### PR TITLE
fix: Override rules that don't apply to test files

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = {
         './rules/react',
         './rules/spothero',
         './rules/stylistic-issues',
-        './rules/variables'
+        './rules/variables',
+        './overrides/tests'
     ].map(require.resolve),
     parser: 'babel-eslint',
     parserOptions: {

--- a/overrides/tests.js
+++ b/overrides/tests.js
@@ -1,0 +1,15 @@
+module.exports = {
+    overrides: [
+        {
+            files: ['**/*.spec.js', '**/*.test.js'],
+            rules: {
+                'max-nested-callbacks': 0,
+                'no-unused-expressions': 0,
+                'no-console': 0,
+                'no-undefined': 0,
+                'react/jsx-handler-names': 0,
+                'camelcase': 0,
+            }
+        }
+    ]
+};

--- a/overrides/tests.js
+++ b/overrides/tests.js
@@ -3,12 +3,12 @@ module.exports = {
         {
             files: ['**/*.spec.js', '**/*.test.js'],
             rules: {
+                'camelcase': 0,
                 'max-nested-callbacks': 0,
                 'no-unused-expressions': 0,
                 'no-console': 0,
                 'no-undefined': 0,
                 'react/jsx-handler-names': 0,
-                'camelcase': 0,
             }
         }
     ]


### PR DESCRIPTION
I pulled in rules that were disabled all over consumer-web and fe-ui